### PR TITLE
Update version to 2.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,9 @@ requirements:
     - {{ stdlib('c') }}
     - make
   host:
-    # 22/8/2025, info from README: zlib version 1.2.6 or later is recommended, which reduces the overhead between blocks.
-    - zlib >=1.2.6
+    - zlib {{ zlib }}
   run:
-    - zlib >=1.2.6
+    - zlib
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "pigz" %}
-{% set version = "2.6" %}
-{% set sha256 = "577673676cd5c7219f94b236075451220bae3e1ca451cf849947a2998fbf5820" %}
+{% set version = "2.8" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/madler/{{ name }}/archive/v{{ version }}.tar.gz 
-  sha256: {{ sha256 }}
+  sha256: 2f7f6a6986996d21cb8658535fff95f1c7107ddce22b5324f4b41890e2904706
 
 build:
   skip: True  # [win]
@@ -18,9 +16,10 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make
   host:
-    # 6/8/2021, info from README: zlib version 1.2.6 or later is recommended, which reduces the overhead between blocks.
+    # 22/8/2025, info from README: zlib version 1.2.6 or later is recommended, which reduces the overhead between blocks.
     - zlib >=1.2.6
   run:
     - zlib >=1.2.6
@@ -31,7 +30,7 @@ test:
     - unpigz -h
 
 about:
-  home: https://zlib.net/pigz/
+  home: https://zlib.net/pigz
   license: zlib
   license_family: other
   license_file: README
@@ -40,6 +39,7 @@ about:
     pigz, which stands for parallel implementation of gzip, is a fully functional
     replacement for gzip that exploits multiple processors and multiple cores
     to the hilt when compressing data.
+  dev_url: https://github.com/madler/pigz/tree/v2.8
   doc_url: https://zlib.net/pigz/pigz.pdf
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ about:
     pigz, which stands for parallel implementation of gzip, is a fully functional
     replacement for gzip that exploits multiple processors and multiple cores
     to the hilt when compressing data.
-  dev_url: https://github.com/madler/pigz/tree/v2.8
+  dev_url: https://github.com/madler/pigz
   doc_url: https://zlib.net/pigz/pigz.pdf
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
 
 about:
   home: https://zlib.net/pigz
-  license: zlib
+  license: Zlib
   license_family: other
   license_file: README
   summary: Parallel implementation of gzip


### PR DESCRIPTION
pigz 2.8

Destination channel: Defaults

Links
[PKG-9105](https://anaconda.atlassian.net/browse/PKG-9105)
dev_url: https://github.com/madler/pigz
conda_forge: https://github.com/conda-forge/pigz-feedstock

Explanation of changes:
new version number


[PKG-9105]: https://anaconda.atlassian.net/browse/PKG-9105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ